### PR TITLE
Use readonly instead of disabled in textarea

### DIFF
--- a/ExtentReports/Views/V3Html/Exception/V3Exception.cshtml
+++ b/ExtentReports/Views/V3Html/Exception/V3Exception.cshtml
@@ -44,7 +44,7 @@
 										<td>@test.StartTime</td>
 										<td class='linked' test-id='@test.TestId'>@test.HierarchicalName</td>
 										<td>
-											<textarea disabled class="code-block">@(((ExceptionInfo)test.ExceptionInfoContext.FirstOrDefault()).Exception.StackTrace)</textarea>
+											<textarea readonly class="code-block">@(((ExceptionInfo)test.ExceptionInfoContext.FirstOrDefault()).Exception.StackTrace)</textarea>
 										</td>
 									</tr>
 									}

--- a/ExtentReports/Views/V3Html/Test/V3Test.cshtml
+++ b/ExtentReports/Views/V3Html/Test/V3Test.cshtml
@@ -197,7 +197,7 @@
 										{
 											if (log.HasException)
 											{
-											<textarea disabled class="code-block">@log.ExceptionInfo.Exception.StackTrace</textarea>
+											<textarea readonly class="code-block">@log.ExceptionInfo.Exception.StackTrace</textarea>
 											}
 											else
 											{
@@ -240,7 +240,7 @@
 												{
 													if (log.HasException)
 													{
-													<textarea disabled class="code-block">@log.ExceptionInfo.Exception.StackTrace</textarea>
+													<textarea readonly class="code-block">@log.ExceptionInfo.Exception.StackTrace</textarea>
 													}
 													else
 													{
@@ -318,7 +318,7 @@
 											<td class='step-details'>
 												@if (log.HasException)
 												{
-													<textarea disabled class="code-block">@log.ExceptionInfo.Exception.StackTrace</textarea>
+													<textarea readonly class="code-block">@log.ExceptionInfo.Exception.StackTrace</textarea>
 												}
 												else
 												{
@@ -394,7 +394,7 @@
 													<td class='step-details'>
 														@if (log.HasException)
 														{
-														<textarea disabled class="code-block">@log.ExceptionInfo.StackTrace</textarea>
+														<textarea readonly class="code-block">@log.ExceptionInfo.StackTrace</textarea>
 														}
 														else
 														{
@@ -479,7 +479,7 @@
 															<td class='step-details'>
 																@if (log.HasException)
 																{
-																<textarea disabled class="code-block">@log.ExceptionInfo.StackTrace</textarea>
+																<textarea readonly class="code-block">@log.ExceptionInfo.StackTrace</textarea>
 																}
 																else
 																{
@@ -564,7 +564,7 @@
 																	<td class='step-details'>
 																		@if (log.HasException)
 																		{
-																		<textarea disabled class="code-block">@log.ExceptionInfo.StackTrace</textarea>
+																		<textarea readonly class="code-block">@log.ExceptionInfo.StackTrace</textarea>
 																		}
 																		else
 																		{


### PR DESCRIPTION
In disabled textarea's, text can't be selected and copied from, which is extremely annoying. This fixes it.